### PR TITLE
Remove import comment to make package usable when cloning from GitHub

### DIFF
--- a/timecode/timecode.go
+++ b/timecode/timecode.go
@@ -36,7 +36,7 @@
 //
 // Timecode and edit rate are stored as a single 64bit integer for efficient
 // timecode handling and comparisons.
-package timecode // import "trimmer.io/go-timecode/timecode"
+package timecode
 
 import (
 	"database/sql/driver"


### PR DESCRIPTION
Right now, calling `go build github.com/trimmer-io/go-timecode/timecode` yields the following error:
```
can't load package: package github.com/trimmer-io/go-timecode/timecode: code in directory /GOPATH/src/github.com/trimmer-io/go-timecode/timecode expects import "trimmer.io/go-timecode/timecode"
```
This issue also causes projects depending on `timecode` to fail building, so a fix is necessary.
I removed the `// import` comment to make the package usable when cloning from GitHub.